### PR TITLE
Update book collection config export and type

### DIFF
--- a/src/content/content.config.ts
+++ b/src/content/content.config.ts
@@ -2,7 +2,7 @@
 import { z, defineCollection } from 'astro:content';
 // 2. Define a schema for each collection you'd like to validate.
 const bookCollection = defineCollection({
-  // type: 'content',
+  type: 'content',
   schema: ({ image }) => z.object({
     title: z.string(),
     author: z.string(),
@@ -18,6 +18,4 @@ const bookCollection = defineCollection({
 }),
 });
 // 3. Export a single `collections` object to register your collection(s)
-export const collections = {
-  'book': bookCollection,
-};
+export const collections = { book };


### PR DESCRIPTION
Sets the 'type' property to 'content' in the book collection definition and simplifies the export statement by directly exporting the 'book' collection. This improves clarity and aligns with Astro content collection conventions.